### PR TITLE
Fix Issue #2: Change which biomes the structure can generate in

### DIFF
--- a/common/src/generated/resources/data/underground_villages/worldgen/structure/underground_village.json
+++ b/common/src/generated/resources/data/underground_villages/worldgen/structure/underground_village.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:jigsaw",
-  "biomes": "#underground_villages:has_structure/village_underground",
+  "biomes": "#minecraft:is_overworld",
   "max_distance_from_center": 80,
   "size": 6,
   "spawn_overrides": {},


### PR DESCRIPTION
Fix #2 
This allows the structure to generate in Terralith and other non-vanilla world generation mods which do not generate the biomes listed in data\underground_villabes\tags\worldgen\biome\has_structure at y = -20 and instead generate unique cave biomes there.

This was tested and working in Terralith 1.20.1 where the .jar file was unpacked, this change was made, the .jar was repacked, and the structures successfully generated when Terralith was running in the world.